### PR TITLE
Add extent command

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,9 @@ node wrapper for ImageMagick commands
 
 - rotate Rotate image, properties { angle: 0, x: 0, y: 0 }
 - crop - Crop image, properties { width: 2560, height: 1013, x: 0, y: 0 }
+- extent - Directly adjust image size, properties { width: 2560, height: 1013 }
 - resize - Resize image, properties { width: 470, height: 186, flag: '>' }, available flags <,>,!,^ for more info read about them in the imagemagick [resize docs](http://www.imagemagick.org/Usage/resize/#noaspect)
-- sharpen - Sharepn image, properties { mode: 'variable' }, available modes are: light, moderate, strong, extreme, off.
+- sharpen - Sharpen image, properties { mode: 'variable' }, available modes are: light, moderate, strong, extreme, off.
 - strip - Strip image of all profiles and comments.
 - quality - Compression quality, defaults to 85.
 

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -129,6 +129,19 @@ ImageMagickCommands.prototype.crop = function (opts) {
 };
 
 /**
+ * Extent
+ * @param  {Object} opts {width, height}
+ * @return {ImageMagickCommands}
+ */
+ImageMagickCommands.prototype.extent = function (opts) {
+	if (!opts.width || !opts.height) {
+		return this;
+	}
+	this.commands.push(printf('-extent %sx%s', opts.width, opts.height));
+	return this;
+};
+
+/**
  * Rotate
  * @param  {Object} opts {angle,x,y,bgColor?}
  * @return {ImageMagickCommands}

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -104,4 +104,18 @@ describe('ImageMagickCommands', function () {
 			cmd.should.equal('convert src.jpg -crop 100x250-10-12 dst.jpg');
 		});
 	});
+
+	describe('#extent', function () {
+		it('should be ignored if width or height is not set', function () {
+			var widthCmd = this.cmds.extent({ width: 100 }).get('src.jpg', 'dst.jpg');
+			var heightCmd = this.cmds.extent({ height: 100 }).get('src.jpg', 'dst.jpg');
+			widthCmd.should.equal('convert src.jpg dst.jpg');
+			heightCmd.should.equal('convert src.jpg dst.jpg');
+		});
+
+		it('should be applied if both width and height are present', function () {
+			var cmd = this.cmds.extent({ width: 100, height: 200 }).get('src.jpg', 'dst.jpg');
+			cmd.should.equal('convert src.jpg -extent 100x200 dst.jpg');
+		});
+	});
 });


### PR DESCRIPTION
Added a command for cropping an image in relation to a given gravity, [as shown in the imagemagick docs](http://www.imagemagick.org/Usage/resize/#fill).

The primary use case for this is to be able to crop the edges off an image (-gravity center) without knowing its dimensions, in order for it to fit into a given box.