### PR TITLE
Support variable density for rendering graphics, add SVG-tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules
 coverage
 package-lock.json
+dst.jpg
+dst.png
+test.jpg

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -82,6 +82,7 @@ function pipeOrPath(obj, format) {
 function ImageMagickCommands(opts) {
 	opts = opts || {};
 	this.executable = opts.executable || 'convert';
+	this.inputOptions = [];
 	this.commands = [];
 	this.maxBuffer = opts.maxBuffer || 1024 * 1024 * 100;
 	this.execOptions = opts.execOptions || {};
@@ -215,6 +216,20 @@ ImageMagickCommands.prototype.quality = function (quality) {
 };
 
 /**
+ * Density
+ * @param  {Number} density
+ * @return {ImageMagickCommands}
+ */
+ImageMagickCommands.prototype.density = function (density) {
+	if (!isNumber(density)) {
+		return this;
+	}
+
+	this.inputOptions.push('-density ' + density);
+	return this;
+};
+
+/**
  * Strip
  * @return {ImageMagickCommands}
  */
@@ -231,7 +246,7 @@ ImageMagickCommands.prototype.strip = function () {
  * @return {String}
  */
 ImageMagickCommands.prototype.get = function (src, dst, outputFormat) {
-	return [this.executable].concat([pipeOrPath(src)], this.commands, [pipeOrPath(dst, outputFormat)]).join(' ');
+	return [this.executable].concat(this.inputOptions, [pipeOrPath(src)], this.commands, [pipeOrPath(dst, outputFormat)]).join(' ');
 };
 
 /**

--- a/test/commands.test.js
+++ b/test/commands.test.js
@@ -126,6 +126,14 @@ describe('ImageMagickCommands', () => {
 		});
 	});
 
+	describe('#density', () => {
+		it('should support variable density', () => {
+			const cmds = new ImageMagickCommands();
+			const cmd = cmds.density(300).get('src.jpg', 'dst.jpg');
+			cmd.should.equal('convert -density 300 src.jpg dst.jpg');
+		});
+	});
+
 	describe('#extent', () => {
 		it('should be ignored if width or height is not set', () => {
 			const cmds = new ImageMagickCommands();

--- a/test/fixtures/small.svg
+++ b/test/fixtures/small.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+	<!ENTITY ns_extend "http://ns.adobe.com/Extensibility/1.0/">
+	<!ENTITY ns_ai "http://ns.adobe.com/AdobeIllustrator/10.0/">
+	<!ENTITY ns_graphs "http://ns.adobe.com/Graphs/1.0/">
+	<!ENTITY ns_vars "http://ns.adobe.com/Variables/1.0/">
+	<!ENTITY ns_imrep "http://ns.adobe.com/ImageReplacement/1.0/">
+	<!ENTITY ns_sfw "http://ns.adobe.com/SaveForWeb/1.0/">
+	<!ENTITY ns_custom "http://ns.adobe.com/GenericCustomNamespace/1.0/">
+	<!ENTITY ns_adobe_xpath "http://ns.adobe.com/XPath/1.0/">
+]>
+<svg version="1.1" id="Livello_1" xmlns:x="&ns_extend;" xmlns:i="&ns_ai;" xmlns:graph="&ns_graphs;"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 533.5 544.3"
+	 style="enable-background:new 0 0 533.5 544.3;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#4285F4;}
+	.st1{fill:#34A853;}
+	.st2{fill:#FBBC04;}
+	.st3{fill:#EA4335;}
+</style>
+<metadata>
+	<sfw  xmlns="&ns_sfw;">
+		<slices></slices>
+		<sliceSourceBounds  bottomLeftOrigin="true" height="544.3" width="533.5" x="0.1" y="110.1"></sliceSourceBounds>
+	</sfw>
+</metadata>
+<g>
+	<path class="st0" d="M533.5,278.4c0-18.5-1.5-37.1-4.7-55.3H272.1v104.8h147c-6.1,33.8-25.7,63.7-54.4,82.7v68h87.7
+		C503.9,431.2,533.5,361.2,533.5,278.4z"/>
+	<path class="st1" d="M272.1,544.3c73.4,0,135.3-24.1,180.4-65.7l-87.7-68c-24.4,16.6-55.9,26-92.6,26c-71,0-131.2-47.9-152.8-112.3
+		H28.9v70.1C75.1,486.3,169.2,544.3,272.1,544.3z"/>
+	<path class="st2" d="M119.3,324.3c-11.4-33.8-11.4-70.4,0-104.2V150H28.9c-38.6,76.9-38.6,167.5,0,244.4L119.3,324.3z"/>
+	<path class="st3" d="M272.1,107.7c38.8-0.6,76.3,14,104.4,40.8l0,0l77.7-77.7C405,24.6,339.7-0.8,272.1,0C169.2,0,75.1,58,28.9,150
+		l90.4,70.1C140.8,155.6,201.1,107.7,272.1,107.7z"/>
+</g>
+</svg>

--- a/test/imagickal.test.js
+++ b/test/imagickal.test.js
@@ -1,7 +1,9 @@
 'use strict';
+
 const Promise = require('bluebird');
 const fs = require('fs');
 const ImagickCommands = require('../lib/commands');
+const execSync = require('child_process').execSync; // eslint-disable-line no-sync
 const im = require(__dirname + '/../');
 const isJPG = require('./helper').isJPG;
 
@@ -9,6 +11,7 @@ require('should');
 
 const imageFile = __dirname + '/fixtures/small.jpg';
 const animImage = __dirname + '/fixtures/anim.gif';
+const svgFile = __dirname + '/fixtures/small.svg';
 
 describe('Imagick', () => {
 	describe('#setDefaults', () => {
@@ -113,6 +116,30 @@ describe('Imagick', () => {
 					dst.should.equal('dst.jpg');
 					done();
 				});
+			});
+		});
+
+		describe('svg', () => {
+			it('should convert svg to jpg', async () => {
+				const dst = await im.transform(svgFile, 'dst.jpg', {});
+				dst.should.equal('dst.jpg');
+				const res = execSync(`identify -format "width:%w height:%h %m" ${dst}`).toString();
+				res.should.match(/width:534 height:544 JPEG/);
+			});
+
+			it('should convert svg to png', async () => {
+				const dst = await im.transform(svgFile, 'dst.png', {});
+				dst.should.equal('dst.png');
+				const res = execSync(`identify -format "width:%w height:%h %m" ${dst}`).toString();
+				res.should.match(/width:534 height:544 PNG/);
+			});
+
+			it('should support variable density', async () => {
+				const dst = await im.transform(svgFile, 'dst.png', { density: 150 });
+				dst.should.equal('dst.png');
+				const res = execSync(`identify -format "width:%w height:%h %m" ${dst}`).toString();
+				res.should.match(/width:834 height:850 PNG/);
+
 			});
 		});
 


### PR DESCRIPTION
Add support for the `density`-option to support variable DPI when using this lib to render graphics. This is an option for the input, rather than a command for the output, so it must be placed prior to the input file/stream. I've added an `inputOptions`-array for this purpose. I've also added a test-file for SVG transforms, and a couple of tests.